### PR TITLE
Add configuring-gotosocial.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ This role *implicitly* depends on:
 - [`com.devture.ansible.role.systemd_docker_base`](https://github.com/devture/com.devture.ansible.role.systemd_docker_base)
 
 Check [defaults/main.yml](defaults/main.yml) for the full list of supported options.
+
+💡 See this [document](docs/configuring-gotosocial.md) for details about setting up the service with this role.

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -1,0 +1,206 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Setting up Docmost
+
+This is an [Ansible](https://www.ansible.com/) role which installs [Docmost](https://docmost.com/) to run as a [Docker](https://www.docker.com/) container wrapped in a systemd service.
+
+Docmost is a free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
+
+See the project's [documentation](https://docmost.com/docs/) to learn what Docmost does and why it might be useful to you.
+
+## Prerequisites
+
+To run a Docmost instance it is necessary to prepare a [Redis](https://redis.io/) server for managing a metadata database.
+
+If you are looking for an Ansible role for Redis, you can check out [this role (ansible-role-redis)](https://github.com/mother-of-all-self-hosting/ansible-role-redis) maintained by the [Mother-of-All-Self-Hosting (MASH)](https://github.com/mother-of-all-self-hosting) team. Note that the team recommends to have a look at [this role (ansible-role-valkey)](https://github.com/mother-of-all-self-hosting/ansible-role-valkey) for [Valkey](https://valkey.io/) instead.
+
+## Adjusting the playbook configuration
+
+To enable Docmost with this role, add the following configuration to your `vars.yml` file.
+
+**Note**: the path should be something like `inventory/host_vars/mash.example.com/vars.yml` if you use the [MASH Ansible playbook](https://github.com/mother-of-all-self-hosting/mash-playbook).
+
+```yaml
+########################################################################
+#                                                                      #
+# docmost                                                              #
+#                                                                      #
+########################################################################
+
+docmost_enabled: true
+
+########################################################################
+#                                                                      #
+# /docmost                                                             #
+#                                                                      #
+########################################################################
+```
+
+### Set the hostname
+
+To enable the Docmost instance you need to set the hostname as well. To do so, add the following configuration to your `vars.yml` file. Make sure to replace `example.com` with your own value.
+
+```yaml
+docmost_hostname: "example.com"
+```
+
+After adjusting the hostname, make sure to adjust your DNS records to point the domain to your server.
+
+**Note**: hosting Docmost under a subpath (by configuring the `docmost_path_prefix` variable) does not seem to be possible due to Docmost's technical limitations.
+
+### Set variables for connecting to a Redis server
+
+As described above, it is necessary to set up a [Redis](https://redis.io/) server for managing a metadata database of a Docmost instance. You can use either KeyDB or Valkey alternatively.
+
+Having configured it, you need to add and adjust the following configuration to your `vars.yml` file, so that the Docmost instance will connect to the server:
+
+```yaml
+docmost_redis_username: ''
+docmost_redis_password: ''
+docmost_redis_host: YOUR_REDIS_SERVER_HOSTNAME_HERE
+docmost_redis_port: 6379
+docmost_redis_dbnumber: ''
+```
+
+Make sure to replace `YOUR_REDIS_SERVER_HOSTNAME_HERE` with the hostname of your Redis server. If the Redis server runs on the same host as Docmost, set `localhost`.
+
+### Configure a storage backend
+
+The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
+
+#### Local filesystem (default)
+
+**By default this role removes uploaded files when uninstalling the service**. In order to make those files persistent, you need to add a Docker volume to mount in the container, so that the directory for storing files is shared with the host machine.
+
+To add the volume, prepare a directory on the host machine and add the following configuration to your `vars.yml` file:
+
+```yaml
+docmost_data_path: /path/on/the/host
+```
+
+Make sure permissions of the directory specified to `/path/on/the/host`.
+
+#### Amazon S3 compatible object storage
+
+To use Amazon S3 or a S3 compatible object storage, add the following configuration to your `vars.yml` file (adapt to your needs):
+
+```yaml
+docmost_environment_variable_storage_driver: s3
+
+# Set a S3 access key ID
+docmost_environment_variable_aws_s3_access_key_id: ''
+
+# Set a S3 secret access key ID
+docmost_environment_variable_aws_s3_secret_access_key: ''
+
+# Set the the region where your S3 bucket is located
+docmost_environment_variable_aws_s3_region: ''
+
+# Set a S3 bucket name to use
+docmost_environment_variable_aws_s3_bucket: ''
+
+# The endpoint URL for your S3 service (optional; set if using a S3 compatible storage like Wasabi and Storj)
+docmost_environment_variable_aws_s3_endpoint: ''
+
+# Control whether to force path style URLs (https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property) for S3 objects
+docmost_environment_variable_aws_s3_force_path_style: false
+```
+
+### Configure the mailer
+
+You can configure a mailer for functions such as user invitation. Docmost supports a SMTP server (default) and Postmark. To set it up, add the following common configuration and settings specific to SMTP server or Postmark to your `vars.yml` file as below (adapt to your needs):
+
+```yaml
+docmost_mailer_enabled: true
+
+# Set the email address that emails will be sent from
+docmost_environment_variable_mail_from_address: hello@example.com
+
+# Set the name that emails will be sent from
+docmost_environment_variable_mail_from_name: docmost
+```
+
+#### Use SMTP server (default)
+
+To use a SMTP server, add the following configuration to your `vars.yml` file:
+
+```yaml
+# Set the hostname of the SMTP server
+docmost_environment_variable_smtp_host: 127.0.0.1
+
+# Set the port to use for the SMTP server
+docmost_environment_variable_smtp_port: 587
+
+# Set the username for the SMTP server
+docmost_environment_variable_smtp_username: ''
+
+# Set the password for the SMTP server
+docmost_environment_variable_smtp_password: ''
+
+# Control whether TLS is used when connecting to the server
+docmost_environment_variable_smtp_secure: false
+
+# Control whether SSL errors are ignored
+docmost_environment_variable_smtp_ignoretls: false
+```
+
+⚠️ **Note**: without setting an authentication method such as DKIM, SPF, and DMARC for your hostname, emails are most likely to be quarantined as spam at recipient's mail servers. If you have set up a mail server with the [MASH project's exim-relay Ansible role](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay), you can enable DKIM signing with it. Refer [its documentation](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#enable-dkim-support-optional) for details.
+
+#### Use Postmark
+
+To use Postmark, add the following configuration to your `vars.yml` file:
+
+```yaml
+docmost_environment_variable_mail_driver: postmark
+
+# Set the token for Postmark
+docmost_environment_variable_postmark_token: ''
+```
+
+### Extending the configuration
+
+There are some additional things you may wish to configure about the component.
+
+Take a look at:
+
+- [`defaults/main.yml`](../defaults/main.yml) for some variables that you can customize via your `vars.yml` file. You can override settings (even those that don't have dedicated playbook variables) using the `docmost_environment_variables_additional_variables` variable
+
+For a complete list of Docmost's config options that you could put in `docmost_environment_variables_additional_variables`, see its [environment variables](https://docmost.com/docs/self-hosting/environment-variables).
+
+## Installing
+
+After configuring the playbook, run the installation command of your playbook as below:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
+
+If you use the MASH playbook, the shortcut commands with the [`just` program](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/just.md) are also available: `just install-all` or `just setup-all`
+
+## Usage
+
+After running the command for installation, Docmost becomes available at the specified hostname like `https://example.com`.
+
+To get started, go to the URL on a web browser and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one specified to `docmost_environment_variable_mail_from_address`.
+
+## Troubleshooting
+
+### Check the service's logs
+
+You can find the logs in [systemd-journald](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) by logging in to the server with SSH and running `journalctl -fu docmost` (or how you/your playbook named the service, e.g. `mash-docmost`).

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -25,12 +25,6 @@ GoToSocial is a self-hosted [ActivityPub](https://activitypub.rocks/) social net
 
 See the project's [documentation](https://docs.gotosocial.org/) to learn what GotoSocial does and why it might be useful to you.
 
-## Prerequisites
-
-To run a GoToSocial instance it is necessary to prepare a [Redis](https://redis.io/) server for managing a metadata database.
-
-If you are looking for an Ansible role for Redis, you can check out [this role (ansible-role-redis)](https://github.com/mother-of-all-self-hosting/ansible-role-redis) maintained by the [Mother-of-All-Self-Hosting (MASH)](https://github.com/mother-of-all-self-hosting) team. Note that the team recommends to have a look at [this role (ansible-role-valkey)](https://github.com/mother-of-all-self-hosting/ansible-role-valkey) for [Valkey](https://valkey.io/) instead.
-
 ## Adjusting the playbook configuration
 
 To enable GoToSocial with this role, add the following configuration to your `vars.yml` file.
@@ -64,22 +58,6 @@ gotosocial_hostname: "example.com"
 After adjusting the hostname, make sure to adjust your DNS records to point the domain to your server.
 
 **Note**: hosting GoToSocial under a subpath (by configuring the `gotosocial_path_prefix` variable) does not seem to be possible due to GoToSocial's technical limitations.
-
-### Set variables for connecting to a Redis server
-
-As described above, it is necessary to set up a [Redis](https://redis.io/) server for managing a metadata database of a GoToSocial instance. You can use either KeyDB or Valkey alternatively.
-
-Having configured it, you need to add and adjust the following configuration to your `vars.yml` file, so that the GoToSocial instance will connect to the server:
-
-```yaml
-gotosocial_redis_username: ''
-gotosocial_redis_password: ''
-gotosocial_redis_host: YOUR_REDIS_SERVER_HOSTNAME_HERE
-gotosocial_redis_port: 6379
-gotosocial_redis_dbnumber: ''
-```
-
-Make sure to replace `YOUR_REDIS_SERVER_HOSTNAME_HERE` with the hostname of your Redis server. If the Redis server runs on the same host as GoToSocial, set `localhost`.
 
 ### Configure a storage backend
 

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -204,25 +204,32 @@ Make sure to change the paths as necessary.
 >[!NOTE]
 > If you use the MASH Ansible playbook, the paths should be set to `/mash/gotosocial/` instead of `/gotosocial/`.
 
-### Install the service and import the database
+### Install the service
 
-Next, install the service (**not starting it**) and import database by running the playbook as below on your local computer:
+Next, install the service by running the playbook as below on your local computer:
 
 ```sh
 yourPC$ ansible-playbook -i inventory/hosts setup.yml --tags=install-all
+```
 
+**Do not run `start` tag yet.** Otherwise, the database could not be imported properly.
+
+### Import the database
+
+After installing it, import the database by running the playbook as below:
+
+```sh
 yourPC$ ansible-playbook -i inventory/hosts setup.yml --tags=import-postgres --extra-vars=server_path_postgres_dump=/gotosocial/latest.sql --extra-vars=postgres_default_import_database=YOUR_POSTGRES_SERVER_DATABASE_NAME_HERE
 ```
 
 Make sure to change the path and replace `YOUR_POSTGRES_SERVER_DATABASE_NAME_HERE` with yours (specified with `gotosocial_database_name`).
 
 >[!NOTE]
-> - Do not run `start` tag yet. Otherwise, the database would not be imported properly.
-> - If you use the MASH Ansible playbook, run this command to import the database: `ansible-playbook -i inventory/hosts setup.yml --tags=import-postgres --extra-vars=server_path_postgres_dump=/mash/gotosocial/latest.sql --extra-vars=postgres_default_import_database=mash-gotosocial`
+> If you use the MASH Ansible playbook, run this command to import the database: `ansible-playbook -i inventory/hosts setup.yml --tags=import-postgres --extra-vars=server_path_postgres_dump=/mash/gotosocial/latest.sql --extra-vars=postgres_default_import_database=mash-gotosocial`
 
 ### Start the services
 
-After installation and importing the database have completed, start the services by running the playbook:
+After importing the database have completed, start the services by running the playbook:
 
 ```sh
 yourPC$ ansible-playbook -i inventory/hosts setup.yml --tags=start

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -201,6 +201,9 @@ serverA$ rsync -av -e "ssh" data/* root@serverB:/gotosocial/data/
 
 Make sure to change the paths as necessary.
 
+>[!NOTE]
+> If you use the MASH Ansible playbook, the paths should be set to `/mash/gotosocial/` instead of `/gotosocial/`.
+
 ### Install
 
 Next, install the service (**not starting it**) and database by running the playbook as below on your local computer:
@@ -212,6 +215,9 @@ yourPC$ ansible-playbook -i inventory/hosts setup.yml --tags=import-postgres --e
 ```
 
 Make sure to change the path and replace `YOUR_POSTGRES_SERVER_DATABASE_NAME_HERE` with yours (specified with `gotosocial_database_name`).
+
+>[!NOTE]
+> If you use the MASH Ansible playbook, run this command to import the database: `ansible-playbook -i inventory/hosts setup.yml --tags=import-postgres --extra-vars=server_path_postgres_dump=/mash/gotosocial/latest.sql --extra-vars=postgres_default_import_database=mash-gotosocial`
 
 ### Start the services
 

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -27,13 +27,13 @@ See the project's [documentation](https://docs.gotosocial.org/) to learn what Go
 
 ## Prerequisites
 
-To run a Docmost instance it is necessary to prepare a [Redis](https://redis.io/) server for managing a metadata database.
+To run a GoToSocial instance it is necessary to prepare a [Redis](https://redis.io/) server for managing a metadata database.
 
 If you are looking for an Ansible role for Redis, you can check out [this role (ansible-role-redis)](https://github.com/mother-of-all-self-hosting/ansible-role-redis) maintained by the [Mother-of-All-Self-Hosting (MASH)](https://github.com/mother-of-all-self-hosting) team. Note that the team recommends to have a look at [this role (ansible-role-valkey)](https://github.com/mother-of-all-self-hosting/ansible-role-valkey) for [Valkey](https://valkey.io/) instead.
 
 ## Adjusting the playbook configuration
 
-To enable Docmost with this role, add the following configuration to your `vars.yml` file.
+To enable GoToSocial with this role, add the following configuration to your `vars.yml` file.
 
 **Note**: the path should be something like `inventory/host_vars/mash.example.com/vars.yml` if you use the [MASH Ansible playbook](https://github.com/mother-of-all-self-hosting/mash-playbook).
 
@@ -55,7 +55,7 @@ docmost_enabled: true
 
 ### Set the hostname
 
-To enable the Docmost instance you need to set the hostname as well. To do so, add the following configuration to your `vars.yml` file. Make sure to replace `example.com` with your own value.
+To enable the GoToSocial instance you need to set the hostname as well. To do so, add the following configuration to your `vars.yml` file. Make sure to replace `example.com` with your own value.
 
 ```yaml
 docmost_hostname: "example.com"
@@ -63,13 +63,13 @@ docmost_hostname: "example.com"
 
 After adjusting the hostname, make sure to adjust your DNS records to point the domain to your server.
 
-**Note**: hosting Docmost under a subpath (by configuring the `docmost_path_prefix` variable) does not seem to be possible due to Docmost's technical limitations.
+**Note**: hosting GoToSocial under a subpath (by configuring the `docmost_path_prefix` variable) does not seem to be possible due to GoToSocial's technical limitations.
 
 ### Set variables for connecting to a Redis server
 
-As described above, it is necessary to set up a [Redis](https://redis.io/) server for managing a metadata database of a Docmost instance. You can use either KeyDB or Valkey alternatively.
+As described above, it is necessary to set up a [Redis](https://redis.io/) server for managing a metadata database of a GoToSocial instance. You can use either KeyDB or Valkey alternatively.
 
-Having configured it, you need to add and adjust the following configuration to your `vars.yml` file, so that the Docmost instance will connect to the server:
+Having configured it, you need to add and adjust the following configuration to your `vars.yml` file, so that the GoToSocial instance will connect to the server:
 
 ```yaml
 docmost_redis_username: ''
@@ -79,7 +79,7 @@ docmost_redis_port: 6379
 docmost_redis_dbnumber: ''
 ```
 
-Make sure to replace `YOUR_REDIS_SERVER_HOSTNAME_HERE` with the hostname of your Redis server. If the Redis server runs on the same host as Docmost, set `localhost`.
+Make sure to replace `YOUR_REDIS_SERVER_HOSTNAME_HERE` with the hostname of your Redis server. If the Redis server runs on the same host as GoToSocial, set `localhost`.
 
 ### Configure a storage backend
 
@@ -125,7 +125,7 @@ docmost_environment_variable_aws_s3_force_path_style: false
 
 ### Configure the mailer
 
-You can configure a mailer for functions such as user invitation. Docmost supports a SMTP server (default) and Postmark. To set it up, add the following common configuration and settings specific to SMTP server or Postmark to your `vars.yml` file as below (adapt to your needs):
+You can configure a mailer for functions such as user invitation. GoToSocial supports a SMTP server (default) and Postmark. To set it up, add the following common configuration and settings specific to SMTP server or Postmark to your `vars.yml` file as below (adapt to your needs):
 
 ```yaml
 docmost_mailer_enabled: true
@@ -182,7 +182,7 @@ Take a look at:
 
 - [`defaults/main.yml`](../defaults/main.yml) for some variables that you can customize via your `vars.yml` file. You can override settings (even those that don't have dedicated playbook variables) using the `docmost_environment_variables_additional_variables` variable
 
-For a complete list of Docmost's config options that you could put in `docmost_environment_variables_additional_variables`, see its [environment variables](https://docmost.com/docs/self-hosting/environment-variables).
+For a complete list of GoToSocial's config options that you could put in `docmost_environment_variables_additional_variables`, see its [environment variables](https://docmost.com/docs/self-hosting/environment-variables).
 
 ## Installing
 
@@ -196,7 +196,7 @@ If you use the MASH playbook, the shortcut commands with the [`just` program](ht
 
 ## Usage
 
-After running the command for installation, Docmost becomes available at the specified hostname like `https://example.com`.
+After running the command for installation, GoToSocial becomes available at the specified hostname like `https://example.com`.
 
 To get started, go to the URL on a web browser and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one specified to `docmost_environment_variable_mail_from_address`.
 

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -25,6 +25,12 @@ GoToSocial is a self-hosted [ActivityPub](https://activitypub.rocks/) social net
 
 See the project's [documentation](https://docs.gotosocial.org/) to learn what GotoSocial does and why it might be useful to you.
 
+## Prerequisites
+
+To run a GotoSocial instance it is necessary to prepare a [Postgres](https://www.postgresql.org) database server.
+
+If you are looking for an Ansible role for it, you can check out [this role (ansible-role-postgres)](https://github.com/mother-of-all-self-hosting/ansible-role-postgres) maintained by the [Mother-of-All-Self-Hosting (MASH)](https://github.com/mother-of-all-self-hosting) team.
+
 ## Adjusting the playbook configuration
 
 To enable GoToSocial with this role, add the following configuration to your `vars.yml` file.

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -171,11 +171,11 @@ docker exec -it gotosocial /gotosocial/gotosocial admin account demote --usernam
 
 If you want to migrate your existing GoToSocial instance to another server, you can follow the procedure described as below.
 
-**Note**: the following assumes you want to migrate from **serverA** to **serverB**, but you just cave to adjust the copy commands if you are on the same server.
+**Note**: the following assumes you will migrate from **serverA** to **serverB**. Adjust the commands for copying files, if you are migrating on the same server (from an existing GoToSocial instance to the new one to start managing it with a playbook, for example).
 
 ### Stop the existing instance
 
-First, stop the existig instance by logging in to **serverA** with SSH and running the command below.
+First, stop the existing instance by logging in to **serverA** with SSH and running the command below.
 
 ```sh
 serverA$ systemctl stop gotosocial

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -58,12 +58,30 @@ gotosocial_enabled: true
 To enable the GoToSocial instance you need to set the hostname as well. To do so, add the following configuration to your `vars.yml` file. Make sure to replace `example.com` with your own value.
 
 ```yaml
-gotosocial_hostname: "example.com"
+gotosocial_hostname: "social.example.com"
 ```
+
+> [!WARNING]
+> Do not replace the value after the GoToSocial instance has already run once. If changed, it stops working properly.
 
 After adjusting the hostname, make sure to adjust your DNS records to point the domain to your server.
 
 **Note**: hosting GoToSocial under a subpath (by configuring the `gotosocial_path_prefix` variable) does not seem to be possible due to GoToSocial's technical limitations.
+
+#### Set a shorter domain for your handle (optional)
+
+On ActivityPub-powered platforms like GoToSocial, the user handle consists of two parts: username and server. For example, if your handle is `@user@social.example.com`, `user` is the username and `social.example.com` indicates the server.
+
+By default, GoToSocial uses `gotosocial_hostname` that you provide for the server's domain, but you can use a shorter one without the subdomain (`example.com`) by adding the following configuration to your `vars.yml` file:
+
+```yaml
+gotosocial_account_domain: "example.com"
+```
+
+> [!WARNING]
+> Do not replace the value after the GoToSocial instance has already run once. If changed, it stops working properly.
+
+**Note**: if you enable it, please have a look at [this page on the official documentation](https://docs.gotosocial.org/en/latest/advanced/host-account-domain/) as you will have to configure the instance for it.
 
 ### Configure a storage backend
 

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -83,56 +83,39 @@ gotosocial_account_domain: "example.com"
 
 **Note**: if you enable it, please have a look at [this page on the official documentation](https://docs.gotosocial.org/en/latest/advanced/host-account-domain/) as you will have to configure the instance for it.
 
-### Configure the mailer
+### Set variables for connecting to a Postgres database server
 
-You can configure a mailer for functions such as user invitation. GoToSocial supports a SMTP server (default) and Postmark. To set it up, add the following common configuration and settings specific to SMTP server or Postmark to your `vars.yml` file as below (adapt to your needs):
+To use a Postgres server, add the following configuration to your `vars.yml` file.
 
-```yaml
-gotosocial_mailer_enabled: true
-
-# Set the email address that emails will be sent from
-gotosocial_environment_variable_mail_from_address: hello@example.com
-
-# Set the name that emails will be sent from
-gotosocial_environment_variable_mail_from_name: gotosocial
+```yml
+gotosocial_database_hostname: YOUR_POSTGRES_SERVER_HOSTNAME_HERE
+gotosocial_database_port: 5432
+gotosocial_database_name: YOUR_POSTGRES_SERVER_DATABASE_NAME_HERE
+gotosocial_database_username: YOUR_POSTGRES_SERVER_USERNAME_HERE
+gotosocial_database_password: YOUR_POSTGRES_SERVER_PASSWORD_HERE
 ```
 
-#### Use SMTP server (default)
+Make sure to replace values for variables with yours.
 
-To use a SMTP server, add the following configuration to your `vars.yml` file:
+### Configure the mailer
+
+You can configure a SMTP mailer for functions such as sending notifications. To set it up, add the following configuration to your `vars.yml` file as below (adapt to your needs):
 
 ```yaml
 # Set the hostname of the SMTP server
-gotosocial_environment_variable_smtp_host: 127.0.0.1
-
-# Set the port to use for the SMTP server
-gotosocial_environment_variable_smtp_port: 587
+gotosocial_smtp_host: 'smtp.example.com'
 
 # Set the username for the SMTP server
-gotosocial_environment_variable_smtp_username: ''
+gotosocial_smtp_username: gotosocial@example.com
 
 # Set the password for the SMTP server
-gotosocial_environment_variable_smtp_password: ''
+gotosocial_smtp_password: yourpassword
 
-# Control whether TLS is used when connecting to the server
-gotosocial_environment_variable_smtp_secure: false
-
-# Control whether SSL errors are ignored
-gotosocial_environment_variable_smtp_ignoretls: false
+# Set the email address that emails will be sent from
+gotosocial_smtp_from: gotosocial@example.com
 ```
 
 ⚠️ **Note**: without setting an authentication method such as DKIM, SPF, and DMARC for your hostname, emails are most likely to be quarantined as spam at recipient's mail servers. If you have set up a mail server with the [MASH project's exim-relay Ansible role](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay), you can enable DKIM signing with it. Refer [its documentation](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#enable-dkim-support-optional) for details.
-
-#### Use Postmark
-
-To use Postmark, add the following configuration to your `vars.yml` file:
-
-```yaml
-gotosocial_environment_variable_mail_driver: postmark
-
-# Set the token for Postmark
-gotosocial_environment_variable_postmark_token: ''
-```
 
 ### Extending the configuration
 
@@ -140,9 +123,9 @@ There are some additional things you may wish to configure about the component.
 
 Take a look at:
 
-- [`defaults/main.yml`](../defaults/main.yml) for some variables that you can customize via your `vars.yml` file. You can override settings (even those that don't have dedicated playbook variables) using the `gotosocial_environment_variables_additional_variables` variable
+- [`defaults/main.yml`](../defaults/main.yml) for some variables that you can customize via your `vars.yml` file. You can override settings (even those that don't have dedicated playbook variables) using the `gotosocial_environment_variables_extension` variable
 
-For a complete list of GoToSocial's config options that you could put in `gotosocial_environment_variables_additional_variables`, see its [environment variables](https://gotosocial.com/docs/self-hosting/environment-variables).
+See [this page](https://docs.gotosocial.org/en/latest/configuration/#environment-variables) of the official documentation for GoToSocial's config options that you could put in `gotosocial_environment_variables_extension`.
 
 ## Installing
 

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -204,9 +204,9 @@ Make sure to change the paths as necessary.
 >[!NOTE]
 > If you use the MASH Ansible playbook, the paths should be set to `/mash/gotosocial/` instead of `/gotosocial/`.
 
-### Install
+### Install the service and import the database
 
-Next, install the service (**not starting it**) and database by running the playbook as below on your local computer:
+Next, install the service (**not starting it**) and import database by running the playbook as below on your local computer:
 
 ```sh
 yourPC$ ansible-playbook -i inventory/hosts setup.yml --tags=install-all
@@ -217,11 +217,12 @@ yourPC$ ansible-playbook -i inventory/hosts setup.yml --tags=import-postgres --e
 Make sure to change the path and replace `YOUR_POSTGRES_SERVER_DATABASE_NAME_HERE` with yours (specified with `gotosocial_database_name`).
 
 >[!NOTE]
-> If you use the MASH Ansible playbook, run this command to import the database: `ansible-playbook -i inventory/hosts setup.yml --tags=import-postgres --extra-vars=server_path_postgres_dump=/mash/gotosocial/latest.sql --extra-vars=postgres_default_import_database=mash-gotosocial`
+> - Do not run `start` tag yet. Otherwise, the database would not be imported properly.
+> - If you use the MASH Ansible playbook, run this command to import the database: `ansible-playbook -i inventory/hosts setup.yml --tags=import-postgres --extra-vars=server_path_postgres_dump=/mash/gotosocial/latest.sql --extra-vars=postgres_default_import_database=mash-gotosocial`
 
 ### Start the services
 
-After installation has completed, start the services by running the playbook:
+After installation and importing the database have completed, start the services by running the playbook:
 
 ```sh
 yourPC$ ansible-playbook -i inventory/hosts setup.yml --tags=start

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -40,15 +40,15 @@ To enable GoToSocial with this role, add the following configuration to your `va
 ```yaml
 ########################################################################
 #                                                                      #
-# docmost                                                              #
+# gotosocial                                                           #
 #                                                                      #
 ########################################################################
 
-docmost_enabled: true
+gotosocial_enabled: true
 
 ########################################################################
 #                                                                      #
-# /docmost                                                             #
+# /gotosocial                                                          #
 #                                                                      #
 ########################################################################
 ```
@@ -58,12 +58,12 @@ docmost_enabled: true
 To enable the GoToSocial instance you need to set the hostname as well. To do so, add the following configuration to your `vars.yml` file. Make sure to replace `example.com` with your own value.
 
 ```yaml
-docmost_hostname: "example.com"
+gotosocial_hostname: "example.com"
 ```
 
 After adjusting the hostname, make sure to adjust your DNS records to point the domain to your server.
 
-**Note**: hosting GoToSocial under a subpath (by configuring the `docmost_path_prefix` variable) does not seem to be possible due to GoToSocial's technical limitations.
+**Note**: hosting GoToSocial under a subpath (by configuring the `gotosocial_path_prefix` variable) does not seem to be possible due to GoToSocial's technical limitations.
 
 ### Set variables for connecting to a Redis server
 
@@ -72,11 +72,11 @@ As described above, it is necessary to set up a [Redis](https://redis.io/) serve
 Having configured it, you need to add and adjust the following configuration to your `vars.yml` file, so that the GoToSocial instance will connect to the server:
 
 ```yaml
-docmost_redis_username: ''
-docmost_redis_password: ''
-docmost_redis_host: YOUR_REDIS_SERVER_HOSTNAME_HERE
-docmost_redis_port: 6379
-docmost_redis_dbnumber: ''
+gotosocial_redis_username: ''
+gotosocial_redis_password: ''
+gotosocial_redis_host: YOUR_REDIS_SERVER_HOSTNAME_HERE
+gotosocial_redis_port: 6379
+gotosocial_redis_dbnumber: ''
 ```
 
 Make sure to replace `YOUR_REDIS_SERVER_HOSTNAME_HERE` with the hostname of your Redis server. If the Redis server runs on the same host as GoToSocial, set `localhost`.
@@ -92,7 +92,7 @@ The service provides these storage backend options: local filesystem (default) a
 To add the volume, prepare a directory on the host machine and add the following configuration to your `vars.yml` file:
 
 ```yaml
-docmost_data_path: /path/on/the/host
+gotosocial_data_path: /path/on/the/host
 ```
 
 Make sure permissions of the directory specified to `/path/on/the/host`.
@@ -102,25 +102,25 @@ Make sure permissions of the directory specified to `/path/on/the/host`.
 To use Amazon S3 or a S3 compatible object storage, add the following configuration to your `vars.yml` file (adapt to your needs):
 
 ```yaml
-docmost_environment_variable_storage_driver: s3
+gotosocial_environment_variable_storage_driver: s3
 
 # Set a S3 access key ID
-docmost_environment_variable_aws_s3_access_key_id: ''
+gotosocial_environment_variable_aws_s3_access_key_id: ''
 
 # Set a S3 secret access key ID
-docmost_environment_variable_aws_s3_secret_access_key: ''
+gotosocial_environment_variable_aws_s3_secret_access_key: ''
 
 # Set the the region where your S3 bucket is located
-docmost_environment_variable_aws_s3_region: ''
+gotosocial_environment_variable_aws_s3_region: ''
 
 # Set a S3 bucket name to use
-docmost_environment_variable_aws_s3_bucket: ''
+gotosocial_environment_variable_aws_s3_bucket: ''
 
 # The endpoint URL for your S3 service (optional; set if using a S3 compatible storage like Wasabi and Storj)
-docmost_environment_variable_aws_s3_endpoint: ''
+gotosocial_environment_variable_aws_s3_endpoint: ''
 
 # Control whether to force path style URLs (https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property) for S3 objects
-docmost_environment_variable_aws_s3_force_path_style: false
+gotosocial_environment_variable_aws_s3_force_path_style: false
 ```
 
 ### Configure the mailer
@@ -128,13 +128,13 @@ docmost_environment_variable_aws_s3_force_path_style: false
 You can configure a mailer for functions such as user invitation. GoToSocial supports a SMTP server (default) and Postmark. To set it up, add the following common configuration and settings specific to SMTP server or Postmark to your `vars.yml` file as below (adapt to your needs):
 
 ```yaml
-docmost_mailer_enabled: true
+gotosocial_mailer_enabled: true
 
 # Set the email address that emails will be sent from
-docmost_environment_variable_mail_from_address: hello@example.com
+gotosocial_environment_variable_mail_from_address: hello@example.com
 
 # Set the name that emails will be sent from
-docmost_environment_variable_mail_from_name: docmost
+gotosocial_environment_variable_mail_from_name: gotosocial
 ```
 
 #### Use SMTP server (default)
@@ -143,22 +143,22 @@ To use a SMTP server, add the following configuration to your `vars.yml` file:
 
 ```yaml
 # Set the hostname of the SMTP server
-docmost_environment_variable_smtp_host: 127.0.0.1
+gotosocial_environment_variable_smtp_host: 127.0.0.1
 
 # Set the port to use for the SMTP server
-docmost_environment_variable_smtp_port: 587
+gotosocial_environment_variable_smtp_port: 587
 
 # Set the username for the SMTP server
-docmost_environment_variable_smtp_username: ''
+gotosocial_environment_variable_smtp_username: ''
 
 # Set the password for the SMTP server
-docmost_environment_variable_smtp_password: ''
+gotosocial_environment_variable_smtp_password: ''
 
 # Control whether TLS is used when connecting to the server
-docmost_environment_variable_smtp_secure: false
+gotosocial_environment_variable_smtp_secure: false
 
 # Control whether SSL errors are ignored
-docmost_environment_variable_smtp_ignoretls: false
+gotosocial_environment_variable_smtp_ignoretls: false
 ```
 
 ⚠️ **Note**: without setting an authentication method such as DKIM, SPF, and DMARC for your hostname, emails are most likely to be quarantined as spam at recipient's mail servers. If you have set up a mail server with the [MASH project's exim-relay Ansible role](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay), you can enable DKIM signing with it. Refer [its documentation](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#enable-dkim-support-optional) for details.
@@ -168,10 +168,10 @@ docmost_environment_variable_smtp_ignoretls: false
 To use Postmark, add the following configuration to your `vars.yml` file:
 
 ```yaml
-docmost_environment_variable_mail_driver: postmark
+gotosocial_environment_variable_mail_driver: postmark
 
 # Set the token for Postmark
-docmost_environment_variable_postmark_token: ''
+gotosocial_environment_variable_postmark_token: ''
 ```
 
 ### Extending the configuration
@@ -180,9 +180,9 @@ There are some additional things you may wish to configure about the component.
 
 Take a look at:
 
-- [`defaults/main.yml`](../defaults/main.yml) for some variables that you can customize via your `vars.yml` file. You can override settings (even those that don't have dedicated playbook variables) using the `docmost_environment_variables_additional_variables` variable
+- [`defaults/main.yml`](../defaults/main.yml) for some variables that you can customize via your `vars.yml` file. You can override settings (even those that don't have dedicated playbook variables) using the `gotosocial_environment_variables_additional_variables` variable
 
-For a complete list of GoToSocial's config options that you could put in `docmost_environment_variables_additional_variables`, see its [environment variables](https://docmost.com/docs/self-hosting/environment-variables).
+For a complete list of GoToSocial's config options that you could put in `gotosocial_environment_variables_additional_variables`, see its [environment variables](https://gotosocial.com/docs/self-hosting/environment-variables).
 
 ## Installing
 
@@ -198,10 +198,10 @@ If you use the MASH playbook, the shortcut commands with the [`just` program](ht
 
 After running the command for installation, GoToSocial becomes available at the specified hostname like `https://example.com`.
 
-To get started, go to the URL on a web browser and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one specified to `docmost_environment_variable_mail_from_address`.
+To get started, go to the URL on a web browser and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one specified to `gotosocial_environment_variable_mail_from_address`.
 
 ## Troubleshooting
 
 ### Check the service's logs
 
-You can find the logs in [systemd-journald](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) by logging in to the server with SSH and running `journalctl -fu docmost` (or how you/your playbook named the service, e.g. `mash-docmost`).
+You can find the logs in [systemd-journald](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) by logging in to the server with SSH and running `journalctl -fu gotosocial` (or how you/your playbook named the service, e.g. `mash-gotosocial`).

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -83,48 +83,6 @@ gotosocial_account_domain: "example.com"
 
 **Note**: if you enable it, please have a look at [this page on the official documentation](https://docs.gotosocial.org/en/latest/advanced/host-account-domain/) as you will have to configure the instance for it.
 
-### Configure a storage backend
-
-The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
-
-#### Local filesystem (default)
-
-**By default this role removes uploaded files when uninstalling the service**. In order to make those files persistent, you need to add a Docker volume to mount in the container, so that the directory for storing files is shared with the host machine.
-
-To add the volume, prepare a directory on the host machine and add the following configuration to your `vars.yml` file:
-
-```yaml
-gotosocial_data_path: /path/on/the/host
-```
-
-Make sure permissions of the directory specified to `/path/on/the/host`.
-
-#### Amazon S3 compatible object storage
-
-To use Amazon S3 or a S3 compatible object storage, add the following configuration to your `vars.yml` file (adapt to your needs):
-
-```yaml
-gotosocial_environment_variable_storage_driver: s3
-
-# Set a S3 access key ID
-gotosocial_environment_variable_aws_s3_access_key_id: ''
-
-# Set a S3 secret access key ID
-gotosocial_environment_variable_aws_s3_secret_access_key: ''
-
-# Set the the region where your S3 bucket is located
-gotosocial_environment_variable_aws_s3_region: ''
-
-# Set a S3 bucket name to use
-gotosocial_environment_variable_aws_s3_bucket: ''
-
-# The endpoint URL for your S3 service (optional; set if using a S3 compatible storage like Wasabi and Storj)
-gotosocial_environment_variable_aws_s3_endpoint: ''
-
-# Control whether to force path style URLs (https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property) for S3 objects
-gotosocial_environment_variable_aws_s3_force_path_style: false
-```
-
 ### Configure the mailer
 
 You can configure a mailer for functions such as user invitation. GoToSocial supports a SMTP server (default) and Postmark. To set it up, add the following common configuration and settings specific to SMTP server or Postmark to your `vars.yml` file as below (adapt to your needs):

--- a/docs/configuring-gotosocial.md
+++ b/docs/configuring-gotosocial.md
@@ -10,19 +10,20 @@ SPDX-FileCopyrightText: 2022 Julian Foad
 SPDX-FileCopyrightText: 2022 Warren Bailey
 SPDX-FileCopyrightText: 2023 Antonis Christofides
 SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
 SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
 SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Setting up Docmost
+# Setting up GotoSocial
 
-This is an [Ansible](https://www.ansible.com/) role which installs [Docmost](https://docmost.com/) to run as a [Docker](https://www.docker.com/) container wrapped in a systemd service.
+This is an [Ansible](https://www.ansible.com/) role which installs [GotoSocial](https://gotosocial.org/) to run as a [Docker](https://www.docker.com/) container wrapped in a systemd service.
 
-Docmost is a free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
+GoToSocial is a self-hosted [ActivityPub](https://activitypub.rocks/) social network server. With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles.
 
-See the project's [documentation](https://docmost.com/docs/) to learn what Docmost does and why it might be useful to you.
+See the project's [documentation](https://docs.gotosocial.org/) to learn what GotoSocial does and why it might be useful to you.
 
 ## Prerequisites
 


### PR DESCRIPTION
This reuses:
- https://github.com/mother-of-all-self-hosting/mash-playbook/blob/03a88d5da6e8e4d3634142125337a9812f0a340b/docs/services/gotosocial.md,
- https://codeberg.org/acioustick/ansible-role-docmost/src/commit/21e11a60a8e3c31283779c5f4aba01d42a77eb82/docs/configuring-docmost.md, and
- https://codeberg.org/acioustick/ansible-role-gotosocial/src/commit/9a54331cf5c921de53b035550e055ece243592f9/README.md.

I have not tested migration but the instruction has been on the MASH playbook, and it seems fine to me.